### PR TITLE
hotfix/BE-14

### DIFF
--- a/App/backend/api/views/auth.py
+++ b/App/backend/api/views/auth.py
@@ -20,7 +20,7 @@ class RegisterView(generics.GenericAPIView):
         tags=['auth'],
         request_body=RegisterSerializer,
         responses={
-            status.HTTP_200_OK: openapi.Response(
+            status.HTTP_201_CREATED: openapi.Response(
                 description="Successfully logged in.",
                 examples={
                     "application/json": {


### PR DESCRIPTION
Registration API returns ```201``` status code upon successful registration. However there was an inconsistency between this behavior and our documentation in ```feature/BE-14```. Purpose of this hotfix to fix that.