### PR TITLE
hotfix/BE-11

### DIFF
--- a/App/backend/docker-compose.yml
+++ b/App/backend/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3.8"
    
 services:
   web:
-    build: .
-    # image: 6f6e28ad14df  (ID of the image - look at it from your local Docker)
+  # build: .      -- use this one if you want to build the local DockerFile
+    image: ghcr.io/bounswe/bounswe2022group8:master
     command: python /project/manage.py runserver 0.0.0.0:8000 --settings=backend.settings.production
     volumes:
       - .:/project


### PR DESCRIPTION
Visibility settings of our Github package is set by @suzan-uskudarli. Now, we should be able to directly use it from our `docker-compose` file. This PR includes just a single line of change to reflect the update. It works on my side but I made the configurations already - so to make sure, I highly suggest someone who didn't create an access token to test it out. 
Simply, pull the branch into your local and run `docker-compose up -d`. Don't forget to open Docker Desktop behind. 

Update: Setting is changed from `Private` to `Internal` - but we have to change it as `Public` to be able to pull the image without having to use an access token.