### PR TITLE
bugfix/BE-17

### DIFF
--- a/App/backend/api/serializers/profile.py
+++ b/App/backend/api/serializers/profile.py
@@ -17,7 +17,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
     # here, we define the parameters we expect to receive (not directly related to model)
     class Meta:
         model = User
-        fields = ['username', 'email', 'name', 'surname', 'about', 'location', 'profile_path', 'is_level2', 'followers', 'followings']
+        fields = ['id', 'username', 'email', 'name', 'surname', 'about', 'location', 'profile_path', 'is_level2', 'followers', 'followings']
 
 
 
@@ -27,4 +27,4 @@ class UserUpdateProfileSerializer(serializers.ModelSerializer):
     # here, we define the parameters we expect to receive (not directly related to model)
     class Meta:
         model = User
-        fields = ['name', 'surname', 'about', 'location', 'profile_path']
+        fields = ['id', 'name', 'surname', 'about', 'location', 'profile_path']

--- a/App/backend/api/urls.py
+++ b/App/backend/api/urls.py
@@ -12,6 +12,7 @@ from .views.profile import profile_api, profile_me_api
 from .views.artitem import get_artitems, artitems_by_userid, artitems_by_username, artitems_by_id, post_artitem, delete_artitem, artitems_of_followings
 from .views.follow import follow_user, unfollow_user, get_my_followers, get_my_followings, get_followers, get_followings
 from .views.comments import CommentView, CommentsView
+from .views.user import users_api
 
 from knox import views as knox_views
 from drf_yasg.utils import swagger_auto_schema
@@ -56,6 +57,7 @@ urlpatterns = [
     path('profile/me/password-reset/', resetPasswordLoggedView, name = "resetPasswordLogged"),
     path('users/profile/<int:id>', profile_api, name="profile_by_id"),
     path('users/profile/me/', profile_me_api, name="profile_me"),
+    path('users/profile/users/', users_api, name="profile_users"),
     path('artitems/<int:artitemid>/comments/', CommentsView, name="CommentsView"),
     path('artitems/<int:artitemid>/comments/<int:id>/', CommentView, name="CommentView"),
     path('artitems/', get_artitems, name="get_all_artitems"),

--- a/App/backend/api/views/profile.py
+++ b/App/backend/api/views/profile.py
@@ -24,6 +24,7 @@ from ..models.user import Follow
             description="Successfully retrieved the profile information of a user.",
             examples={
                 "application/json": {
+                    "id": 1,
                     "username": "pothepanda",
                     "email": "po@jade.edu",
                     "location": "China",
@@ -72,6 +73,7 @@ def profile_api(request, id):
             description="Successfully retrieved the profile information of the current user.",
             examples={
                 "application/json": {
+                    "id": 1,
                     "username": "budgie",
                     "email": "budgie@mit.edu",
                     "name": "Salvador",
@@ -116,6 +118,7 @@ def profile_api(request, id):
             description="Successfully updated the profile of the user, here are the updated values:",
             examples={
                 "application/json": {
+                    "id": 1,
                     "name": "Captain Joseph",
                     "surname": "Blocker",
                     "about": "A veteran of the Indian Wars, who is deeply interested in impressionist art.",

--- a/App/backend/api/views/user.py
+++ b/App/backend/api/views/user.py
@@ -1,0 +1,49 @@
+from django.shortcuts import render
+from rest_framework import status
+from rest_framework.response import Response
+
+from ..serializers.profile import UserProfileSerializer
+
+from ..models.user import User
+from rest_framework import permissions
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import api_view, permission_classes
+from drf_yasg import openapi
+
+
+# http://${host}:8000/api/v1/profile/users  : Return all the users in the system   
+
+@ swagger_auto_schema(
+    method='get',
+    operation_description="Returns all the users in the system with their profile information",
+    operation_summary="Get all users in the system.",
+    tags=['profile'],
+    responses={
+        status.HTTP_200_OK: openapi.Response(
+            description="Successfully retrieved the users.",
+            examples={
+                "application/json": [{
+                    "username": "pothepanda",
+                    "email": "po@jade.edu",
+                    "location": "China",
+                    "name": "Po",
+                    "surname": "Ping",
+                    "about": """The foretold Dragon Warrior of legend, a master of the Panda Style of Kung Fu, noodle lover and an art enthusiast.""",
+                    "profile_path": "avatar/default.png",
+                    "is_level2": False,
+                    "followers": 3,
+                    "followings": 2
+                }]
+            }
+        )
+    }
+)
+@api_view(['GET'])
+@permission_classes([permissions.AllowAny])
+def users_api(request):
+    if (request.method == "GET"):
+        user = User.objects.all()
+        serializer = UserProfileSerializer(user, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    else:
+        return Response({"detail": "Method \"{}\" not allowed.".format(request.method)})


### PR DESCRIPTION
Problem: When an art item is deleted from the system, it is still stored in the related S3 bucket. This doesn't affect the functionality in frontend or mobile - yet it's very inefficient to store images that are already gone from the application.
Solution: Delete the image from S3 as well using `boto3` client.

Problem: Profile APIs were not returning ID of the user. 
Solution: Updated related serializers and documentation.

Problem: Frontend can't populate their `Discover` page with users since recommendation engine is not implemented yet.
Quick Solution: Implemented a GET API that returns all the users. This way they can feed the related pages with pagination.

Tested both on local and using Dockerized version.