### PR TITLE
feature/BE-30

### DIFF
--- a/App/backend/api/serializers/serializers.py
+++ b/App/backend/api/serializers/serializers.py
@@ -50,4 +50,4 @@ class CommentSerializer(serializers.ModelSerializer):
 class SimpleUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'username', 'name', 'surname']
+        fields = ['id', 'username', 'name', 'surname',  'profile_path']

--- a/App/backend/api/views/artitem.py
+++ b/App/backend/api/views/artitem.py
@@ -51,7 +51,8 @@ from django.core.files.base import ContentFile
                             "id": 11,
                             "username": "JosephBlocker",
                             "name": "Captain Joseph",
-                            "surname": "Blocker"
+                            "surname": "Blocker",
+                            "profile_path": "avatar/default.png"
                         },
                         "type": "sketch",
                         "tags": [],
@@ -98,7 +99,8 @@ def get_artitems(request):
                             "id": 11,
                             "username": "JosephBlocker",
                             "name": "Captain Joseph",
-                            "surname": "Blocker"
+                            "surname": "Blocker",
+                            "profile_path": "avatar/default.png"
                         },
                         "type": "sketch",
                         "tags": [1],
@@ -220,7 +222,8 @@ def delete_artitem(request, id):
                             "id": 11,
                             "username": "JosephBlocker",
                             "name": "Captain Joseph",
-                            "surname": "Blocker"
+                            "surname": "Blocker",
+                            "profile_path": "avatar/default.png"
                         },
                         "type": "sketch",
                         "tags": [],
@@ -269,7 +272,8 @@ def artitems_by_id(request, id):
                             "id": 11,
                             "username": "JosephBlocker",
                             "name": "Captain Joseph",
-                            "surname": "Blocker"
+                            "surname": "Blocker",
+                            "profile_path": "avatar/default.png"
                         },
                         "type": "sketch",
                         "tags": [],
@@ -319,7 +323,8 @@ def artitems_by_userid(request, id):
                             "id": 11,
                             "username": "JosephBlocker",
                             "name": "Captain Joseph",
-                            "surname": "Blocker"
+                            "surname": "Blocker",
+                            "profile_path": "avatar/default.png"
                         },
                         "type": "sketch",
                         "tags": [],
@@ -368,7 +373,8 @@ def artitems_by_username(request, username):
                             "id": 9,
                             "username": "till_i_collapse",
                             "name": "",
-                            "surname": ""
+                            "surname": "",
+                            "profile_path": "avatar/default.png"
                         },
                         "title": "Portrait of Joel Miller",
                         "description": "Joel Miller from TLOU universe.",


### PR DESCRIPTION
Right now, after fetching all the art items, mobile sends another API request to fetch the profile images. To avoid that request bottleneck, I include `artitem_path` information in the response of artitem GET APIs. Updated the corresponding serializer and Swagger documentation.