### PR TITLE
feature/FE-31:Backend Connection of Recommendation

### DIFF
--- a/App/backend/api/views/recommendation.py
+++ b/App/backend/api/views/recommendation.py
@@ -112,7 +112,7 @@ def RecommendArtItemView(request):
 
             artitems = []
 
-            firstcategory = ArtItem.objects.filter(category = category1)
+            firstcategory = ArtItem.objects.filter(category = category1).exclude(virtualExhibition__isnull = False)
             for item in firstcategory:
                 histories = History.objects.filter(user=user, is_art=True, art_id=item.id)
                 if(len(histories) == 0):
@@ -120,7 +120,7 @@ def RecommendArtItemView(request):
                 if(len(artitems)>=5):
                     break
             #print(artitems)
-            secondcategory = ArtItem.objects.filter(category = category2)
+            secondcategory = ArtItem.objects.filter(category = category2).exclude(virtualExhibition__isnull = False)
             for item in secondcategory:
                 histories = History.objects.filter(user=user, is_art=True, art_id=item.id)
                 if(len(histories) == 0):
@@ -128,7 +128,7 @@ def RecommendArtItemView(request):
                 if(len(artitems)>=5):
                     break
             #print(artitems)
-            thirdcategory = ArtItem.objects.filter(category = category3)
+            thirdcategory = ArtItem.objects.filter(category = category3).exclude(virtualExhibition__isnull = False)
             for item in thirdcategory:
                 histories = History.objects.filter(user=user, is_art=True, art_id=item.id)
                 if(len(histories) == 0):
@@ -138,7 +138,7 @@ def RecommendArtItemView(request):
             #print(artitems)
             if(len(artitems)<15):   
                 #Django querysets are lazy. That means a query will hit the database only when you specifically ask for the result.         
-                items = ArtItem.objects.all()
+                items = ArtItem.objects.all().exclude(virtualExhibition__isnull = False)
                 for item in items:
                     histories = History.objects.filter(user=user, is_art=True, art_id=item.id)
                     if(len(histories)==0):

--- a/App/frontend/src/pages/RecommendedPages/RecommendedArtitems.js
+++ b/App/frontend/src/pages/RecommendedPages/RecommendedArtitems.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { HOST } from "../../constants/host";
 import Layout from "../../layout/Layout";
 import * as dotenv from "dotenv";
+import { useAuth } from "../../auth/authentication";
 
 import "../styles/Recommendation.css";
 
@@ -16,7 +17,7 @@ function RecommendedArtitems(props) {
   }
 
   const navigate = useNavigate();
-
+  const { token } = useAuth();
   var host = HOST;
 
   const [artItemInfos, setArtItemInfos] = useState([]);
@@ -33,24 +34,25 @@ function RecommendedArtitems(props) {
 
   useEffect(() => {
     // dont forget the put the slash at the end
-    fetch(`${host}/api/v1/artitems/`, {
+    fetch(`${host}/api/v1/recommendations/artitems/`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+         Authorization: `Token ${token}`,
       },
     })
       .then((response) => response.json())
       .then((response) => {
-        //console.log(response);
-        setArtItemInfos(response);
+        console.log(response.artitems);
+        setArtItemInfos(response.artitems);
 
         var bucket = process.env.REACT_APP_AWS_STORAGE_BUCKET_NAME;
         var art_item_paths = [];
 
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < response.artitems.length; i++) {
           var params = {
             Bucket: bucket,
-            Key: response[i].artitem_path,
+            Key: response.artitems[i].artitem_path,
           };
 
           var artitem_url = s3.getSignedUrl("getObject", params);

--- a/App/frontend/src/pages/RecommendedPages/RecommendedExhibitions.js
+++ b/App/frontend/src/pages/RecommendedPages/RecommendedExhibitions.js
@@ -1,30 +1,118 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Layout from "../../layout/Layout";
+import { useNavigate } from "react-router-dom";
+import { HOST } from "../../constants/host";
+import * as dotenv from "dotenv";
+import { useAuth } from "../../auth/authentication";
 
 import { SampleExhibitions } from "../data/SampleExhibitions";
 
 import "../styles/Recommendation.css";
 
 function RecommendedExhibitions(props) {
+  function scrollToTop() {
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "instant",
+    });
+  }
+
+  const navigate = useNavigate();
+  const { token } = useAuth();
+  var host = HOST;
+
+  const [exhibitionInfos, setExhibitionInfos] = useState([]);
+  const [exhibitionPaths, setExhibitionPaths] = useState([]);
+
+  const AWS = require("aws-sdk");
+  dotenv.config();
+  AWS.config.update({
+    accessKeyId: process.env.REACT_APP_AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.REACT_APP_AWS_SECRET_ACCESS_KEY,
+  });
+
+  const s3 = new AWS.S3();
+
+  useEffect(() => {
+    // dont forget the put the slash at the end
+    fetch(`${host}/api/v1/recommendations/exhibitions/`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+         Authorization: `Token ${token}`,
+      },
+    })
+      .then((response) => response.json())
+      .then((response) => {
+        //console.log(response);
+        setExhibitionInfos(response.exhibitions);
+
+        var bucket = process.env.REACT_APP_AWS_STORAGE_BUCKET_NAME;
+        var exhibition_paths = [];
+
+        for (let i = 0; i < response.exhibitions.length; i++) {
+          var params = {
+            Bucket: bucket,
+            Key: response.exhibitions[i].artitem_path,
+          };
+
+          var artitem_url = s3.getSignedUrl("getObject", params);
+
+          exhibition_paths.push(artitem_url);
+        }
+
+        setExhibitionPaths(exhibition_paths);
+      })
+      .catch((error) => console.error("Error:", error));
+  }, [host]);
+
+  function goToExhibition(id) {
+    navigate(`/exhibitions/online/${id}`);
+    scrollToTop();
+  }
+
   return (
     <Layout>
       <div class="recommendation-container">
         <div class="recommendation-grid">
           <h1 className="page-header">Discover Exhibitions</h1>
-          <div className="list">
-            {SampleExhibitions.map((val, key) => {
-              return (
-                <div key={key} className="recommendation-card">
-                  <img className="art-related" src={val.src} alt="" />
-                  <div class="artitem-context">
-                    <h4>{val.name}</h4>
-                    <p>{val.owner}</p>
-                    <p>{val.date}</p>
+
+          {exhibitionInfos.length !== 0 ? (
+            <div className="art-gallery">
+              {exhibitionInfos.slice(0, 5).map((val, index) => {
+                return (
+                  <div
+                    key={val.id}
+                    className="recommendation-card"
+                    onClick={() => goToExhibition(val.id)}
+                  >
+                    <img
+                      className="art-related"
+                      src={exhibitionPaths[index]}
+                      alt={val.description}
+                    />
+                    <div class="artitem-context">
+                      <h4>{val.title}</h4>
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="art-gallery">
+              {SampleExhibitions.map((val, key) => {
+                return (
+                  <div key={key} className="recommendation-card">
+                    <img className="art-related" src={val.src} alt="" />
+                    <div class="artitem-context">
+                      <h4>{val.name}</h4>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
     </Layout>

--- a/App/frontend/src/pages/RecommendedPages/RecommendedUsers.js
+++ b/App/frontend/src/pages/RecommendedPages/RecommendedUsers.js
@@ -35,24 +35,25 @@ function RecommendedUsers(props) {
 
   useEffect(() => {
     // dont forget the put the slash at the end
-    fetch(`${host}/api/v1/users/profile/users/`, {
+    fetch(`${host}/api/v1/recommendations/users/`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Token ${token}`,
       },
     })
       .then((response) => response.json())
       .then((response) => {
         //console.log(response);
-        setAllUsers(response);
+        setAllUsers(response.users);
 
         var bucket = process.env.REACT_APP_AWS_STORAGE_BUCKET_NAME;
         var profile_photos = [];
 
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < response.users.length; i++) {
           var params = {
             Bucket: bucket,
-            Key: response[i].profile_path,
+            Key: response.users[i].profile_path,
           };
 
           var profile_path = s3.getSignedUrl("getObject", params);


### PR DESCRIPTION
As we discussed #393 , recommendation urls provided by backend were implemented. Because we only let registered users to see discover page, token is provided while fetching, which also prevents recommending user to herself . Because there are some problems in terms of exhibition, recommendation url for online exhibitions returns [ ]  even I created online exhibition. That's why, I implemented that if it returns empty, hardcoded exhibition posters will be displayed. If not, response will be displayed.